### PR TITLE
Inline fmt

### DIFF
--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -53,6 +53,8 @@ runs:
 
     - name: Commit Readmes 
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,16 +57,18 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for rfile in ${before_list[@]}; do
-          echo "File to check: $rfile"
-          after=$(sha256sum $rfile| awk '{print $1}' )
-          rcheck=$(cat .readmechanges| grep $after )
-          echo "after: $after, rcheck: $rcheck"
-          # if [ -z "$rcheck" ]; then
-          #   echo "$rfile is new"
-          #   echo "isnewreadme $rfile" >> .readmechanges
-          # fi
-        done;
+        git diff --name-only
+        # for rfile in ${before_list[@]}; do
+        #   echo "File to check: $rfile"
+        #   after=$(sha256sum $rfile| awk '{print $1}' )
+        #   grep -E $after 
+        #   # rcheck=$(cat .readmechanges| grep $after )
+        #   # echo "after: $after, rcheck: $rcheck"
+        #   # if [ -z "$rcheck" ]; then
+        #   #   echo "$rfile is new"
+        #   #   echo "isnewreadme $rfile" >> .readmechanges
+        #   # fi
+        # done;
 
         # # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -59,7 +59,7 @@ runs:
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for i in ${before_list}; do echo "before_list item $i"
         for rfile in ${before_list}; do    
-          echo 'File rfile: $rfile'
+          echo 'File rfile, $rfile';
           # after=$(sha256sum $rfile|awk '{print $1}')    
           # check=$(grep -e $after .readmechanges)    
           # if [ -z "$check" ]; then                                                                                                                                          

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -43,6 +43,6 @@ runs:
         output-method: inject
         git-push: false 
 
-    - name: Git diff
+    - name: Show readme
       shell: bash
-      run: git diff
+      run: cat README.md 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -55,6 +55,7 @@ runs:
       shell: bash
       run: |
         # Go through the list and compare, tag and append new stuff to list
+        test -f .readmechanges && echo "File exists"
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for compare in $before_list; do    
           after=$(sha256sum $compare|awk '{print $1}')    

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -24,7 +24,7 @@ runs:
     
     - name: Echo Values
       shell: bash
-      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }}"
+      run: echo "Branch; ${{ steps.getbranch.outputs.branch }}"
 
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
@@ -34,10 +34,10 @@ runs:
       run: |
         formatted=$(terraform fmt -recursive)
         for fixed in $formatted; do
-          local BRANCH="${{ steps.getbranch.outputs.branch }}"
-          local MESSAGE="chore: Terraform fmt of $fixed from common workflows"
-          local export SHA=$( git rev-parse $BRANCH:$fixed )
-          local export CONTENT=$( base64 -i $fixed )
+          BRANCH="${{ steps.getbranch.outputs.branch }}"
+          MESSAGE="chore: Terraform fmt of $fixed from common workflows"
+          export SHA=$( git rev-parse $BRANCH:$fixed )
+          export CONTENT=$( base64 -i $fixed )
           gh api --method PUT /repos/defenseunicorns/${{ github.repository }}/contents/$fixed \
             --field message="$MESSAGE" \
             --field content="$CONTENT" \

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,16 +57,15 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for i in ${before_list[@]}; do echo "before_list item $i"; done;
-        # for rfile in ${before_list[@]}; do    
-        #   echo $rfile
-        #   # after=$(sha256sum $rfile|awk '{print $1}')    
-        #   # check=$(grep -e $after .readmechanges)    
-        #   # if [ -z "$check" ]; then                                                                                                                                          
-        #   #   echo "$rfile is new!"
-        #   #   echo "isnewreadme $rfile" >> .readmechanges    
-        #   # fi                                                                                                                                                                                              
-        # done;
+        for rfile in ${before_list[@]}; do
+          echo "File to check: $rfile"
+          after=$(sha256sum $rfile|awk '{print $1}')
+          check=$(grep -e $after .readmechanges)
+          if [-z "check" ]; then
+            echo "$file is new"
+            echo "isnewreadme $rfile" >> .readmechanges
+          fi
+        done;
 
         # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -73,12 +73,13 @@ runs:
 
           if [ 0 -eq $match ]; then                                                                                                                                 
             # Say which file is being committed and commit it. 
-            echo "$rfile is new"
+            newdoc=${rfile:2}
+            echo "$newdoc is new"
             BRANCH="${{ github.ref_name }}"
-            MESSAGE="chore: Terraform document updated $rfile from common workflows"
-            SHA=$( git rev-parse $BRANCH:$rfile )
-            CONTENT=$( base64 -i $rfile )
-            gh api --method PUT /repos/${{ github.repository }}/contents/$rfile \
+            MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+            SHA=$( git rev-parse $BRANCH:$newdoc )
+            CONTENT=$( base64 -i $newdoc )
+            gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
               --field message="$MESSAGE" \
               --field content="$CONTENT" \
               --field encoding="base64" \

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -35,6 +35,8 @@ runs:
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         recursive: true
-        git-commit-message: "chore: Auto updating Terraform Docs"
-        git-push: true
-        git-push-sign-off: true
+        git-push: false
+    
+    - name: Check diff
+      shell: bash
+      run: git diff

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -59,14 +59,14 @@ runs:
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for i in ${before_list}; do echo "before_list item $i"
         for rfile in ${before_list}; do    
-          echo 'File rfile, $rfile';
+          echo $rfile
           # after=$(sha256sum $rfile|awk '{print $1}')    
           # check=$(grep -e $after .readmechanges)    
           # if [ -z "$check" ]; then                                                                                                                                          
           #   echo "$rfile is new!"
           #   echo "isnewreadme $rfile" >> .readmechanges    
           # fi                                                                                                                                                                                              
-        done
+        done;
 
         # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
@@ -84,4 +84,3 @@ runs:
         #     --field sha="$SHA"
         #   sleep 1
         # done;
-        

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -34,12 +34,12 @@ runs:
     - name: Set Diff Readme recursive
       shell: bash
       run: |
-      # Stash a list of all readme's found and their sha
-      readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
-      for readme in $readme_list; do
-        echo "Readme found: $readme"
-        sha256sum $readme >> .readmechanges
-      done;
+        # Stash a list of all readmes found and their sha
+        readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
+        for readme in $readme_list; do
+          echo "Readme found: $readme"
+          sha256sum $readme >> .readmechanges
+        done;
 
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -67,8 +67,8 @@ runs:
         # done;  
         
         # Only changed documents here
-        newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
-        for i in $newdocs; do echo "Changed $newdoc"; done
+        newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
+        for i in $newdocs; do echo 'Changed $newdoc'; done
         # for newdoc in $newdocs; do
         #   BRANCH="${{ github.ref_name }}"
         #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -61,25 +61,26 @@ runs:
           echo "File to check: $rfile"
           after=$(sha256sum $rfile|awk '{print $1}')
           check=$(grep -e $after .readmechanges)
-          if [ -z "$check" ]; then
-            echo "$file is new"
-            echo "isnewreadme $rfile" >> .readmechanges
-          fi
+          echo "check: $check, after: $after"
+          # if [ -z "$check" ]; then
+          #   echo "$file is new"
+          #   echo "isnewreadme $rfile" >> .readmechanges
+          # fi
         done;
 
-        # Only changed documents here
-        # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
-        # for i in $newdocs; do echo 'Changed $i'; done
-        # for newdoc in $newdocs; do
-        #   BRANCH="${{ github.ref_name }}"
-        #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"
-        #   SHA=$( git rev-parse $BRANCH:$newdoc )
-        #   CONTENT=$( base64 -i $newdoc )
-        #   gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
-        #     --field message="$MESSAGE" \
-        #     --field content="$CONTENT" \
-        #     --field encoding="base64" \
-        #     --field branch="$BRANCH" \
-        #     --field sha="$SHA"
-        #   sleep 1
-        # done;
+        Only changed documents here
+        newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
+        for i in $newdocs; do echo 'Changed $i'; done
+        for newdoc in $newdocs; do
+          BRANCH="${{ github.ref_name }}"
+          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+          SHA=$( git rev-parse $BRANCH:$newdoc )
+          CONTENT=$( base64 -i $newdoc )
+          gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
+            --field message="$MESSAGE" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="$BRANCH" \
+            --field sha="$SHA"
+          sleep 1
+        done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -58,11 +58,11 @@ runs:
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for rfile in ${before_list[@]}; do
-          echo "File to check: $rfile"
+          echo "File to rcheck: $rfile"
           after=$(sha256sum $rfile| awk '{print $1}' )
-          # check=$(grep -e $after .readmechanges )
-          echo "after: $after"
-          # if [ -z "$check" ]; then
+          rcheck=$(grep -e $after .readmechanges )
+          echo "after: $after, rcheck: $rcheck"
+          # if [ -z "$rcheck" ]; then
           #   echo "$file is new"
           #   echo "isnewreadme $rfile" >> .readmechanges
           # fi

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -6,38 +6,19 @@ inputs:
     description: GitHub token to authenticate to the GitHub REST API from the host repo
     required: true
 
-# output:
-#   formatted-tf:
-#     description: Files Terraform fmt fixed
-#     value: ${{ steps.tffmt.outputs.formatted }}
-#   branch:
-#     description: Current branch 
-#     value: ${{ steps.getbranch.outputs.branch }}
-
 runs:
   using: composite 
   steps:
-    - name: Get branch
-      shell: bash
-      id: getbranch 
-      run: echo "branch=$(git branch|grep \* |awk '{print $2}')" >> $GITHUB_OUTPUT
-    
-    - name: Echo Values
-      shell: bash
-      run: echo "Branch; ${{ github.ref_name }}"
-      # run: echo "Branch; ${{ steps.getbranch.outputs.branch }}"
-
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
       shell: bash
       env:
-        # GITHUB_TOKEN: ${{ inputs.github-token }}
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         formatted=$(terraform fmt -recursive)
         for i in $formatted; do echo $i; done;
         for fixed in $formatted; do
-          BRANCH="${{ steps.getbranch.outputs.branch }}"
+          BRANCH="${{ branch.ref_name }}"
           MESSAGE="chore: Terraform fmt of $fixed from common workflows"
           SHA=$( git rev-parse $BRANCH:$fixed )
           CONTENT=$( base64 -i $fixed )
@@ -49,3 +30,5 @@ runs:
             --field sha="$SHA"
           sleep 1
         done;
+
+      

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -54,21 +54,21 @@ runs:
     - name: Commit Readmes 
       shell: bash
       run: |
-        # # Go through the list and compare, tag and append new stuff to list
-        # before_list=$(cat .readmechanges|awk '{print $2}')    
-        # for compare in $before_list; do    
-        #   after=$(sha256sum $compare|awk '{print $1}')    
-        #   check=$(grep -e $after .readmechanges)    
-        #   if [ -z "$check" ]; then                                                                                                                                          
-        #     echo "$compare is new!"
-        #     echo "isnewreadme $compare" >> .readmechanges    
-        #   fi                                                                                                                                                                                              
-        # done;  
+        # Go through the list and compare, tag and append new stuff to list
+        before_list=$(cat .readmechanges|awk '{print $2}')    
+        for compare in $before_list; do    
+          after=$(sha256sum $compare|awk '{print $1}')    
+          check=$(grep -e $after .readmechanges)    
+          if [ -z "$check" ]; then                                                                                                                                          
+            echo "$compare is new!"
+            echo "isnewreadme $compare" >> .readmechanges    
+          fi                                                                                                                                                                                              
+        done;  
 
-        # # Only changed documents here
-        # newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
+        # Only changed documents here
+        newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
 
-        # for i in $newdocs; do echo "Changed $newdoc"; done
+        for i in $newdocs; do echo "Changed $newdoc"; done
         # for newdoc in $newdocs; do
         #   BRANCH="${{ github.ref_name }}"
         #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"
@@ -82,5 +82,3 @@ runs:
         #     --field sha="$SHA"
         #   sleep 1
         # done;
-
-        echo "Testing indents"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -7,3 +7,10 @@ runs:
     - name: Run Terraform formatting
       shell: bash
       run: terraform fmt -recursive
+    
+    - uses: actions/checkout@v2
+    - run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git commit -am "Fixed Terraform Formatting in GitHub action"
+        git push

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -61,7 +61,7 @@ runs:
           echo "File to check: $rfile"
           after=$(sha256sum $rfile|awk '{print $1}')
           check=$(grep -e $after .readmechanges)
-          if [-z "$check" ]; then
+          if [ -z "$check" ]; then
             echo "$file is new"
             echo "isnewreadme $rfile" >> .readmechanges
           fi

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -68,7 +68,7 @@ runs:
         
         # Only changed documents here
         newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
-        for i in $newdocs; do echo 'Changed $newdoc'; done
+        for i in $newdocs; do echo 'Changed $i'; done
         # for newdoc in $newdocs; do
         #   BRANCH="${{ github.ref_name }}"
         #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -34,6 +34,7 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         formatted=$(terraform fmt -recursive)
+        for i in $formatted; do echo $i; done;
         for fixed in $formatted; do
           BRANCH="${{ steps.getbranch.outputs.branch }}"
           MESSAGE="chore: Terraform fmt of $fixed from common workflows"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -43,6 +43,22 @@ runs:
         output-method: inject
         git-push: false 
 
-    - name: Show readme
+    - name: Commit Readmes 
       shell: bash
-      run: cat README.md 
+      run: |
+        newdocs=$(git status|grep README|awk '{print $2}')
+        for i in $newdocs; do echo "Changed: $newdoc"; done
+        for push in $newdocs; do
+          BRANCH="${{ github.ref_name }}"
+          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+          SHA=$( git rev-parse $BRANCH:$push )
+          CONTENT=$( base64 -i $push )
+          gh api --method PUT /repos/${{ github.repository }}/contents/$push \
+            --field message="$MESSAGE" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="$BRANCH" \
+            --field sha="$SHA"
+          sleep 1
+        done;
+          

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -60,7 +60,7 @@ runs:
         for rfile in ${before_list[@]}; do
           echo "File to check: $rfile"
           after=$(sha256sum $rfile| awk '{print $1}' )
-          rcheck=$(grep -E $after .readmechanges )
+          rcheck=$(cat .readmechanges| grep $after )
           echo "after: $after, rcheck: $rcheck"
           # if [ -z "$rcheck" ]; then
           #   echo "$rfile is new"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -38,6 +38,6 @@ runs:
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
-        recursive: true
+        recursive: false 
         output-method: inject
         git-push: false 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,6 +57,7 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
+        for i in ${before_list}; do echo "before_list item $i"; done;
         for compare in ${before_list[@]}; do    
           echo 'File compare: $compare'
           # after=$(sha256sum $compare|awk '{print $1}')    

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -31,12 +31,15 @@ runs:
           sleep 1
         done;
 
+    - name: Sync repo
+      uses: actions/checkout@v3
+
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
+        working-dir: .
         recursive: true
-        git-push: false
-    
-    - name: Check diff
-      shell: bash
-      run: git diff
+        output-method: inject
+        git-commit-message: Updating docs from Terraform GitHub Actions common workflows
+        git-push: true
+        git-push-sign-off: true

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -6,13 +6,13 @@ inputs:
     description: GitHub token to authenticate to the GitHub REST API from the host repo
     required: true
 
-output:
-  formatted-tf:
-    description: Files Terraform fmt fixed
-    value: ${{ steps.tffmt.outputs.formatted }}
-  branch:
-    description: Current branch 
-    value: ${{ steps.getbranch.outputs.branch }}
+# output:
+#   formatted-tf:
+#     description: Files Terraform fmt fixed
+#     value: ${{ steps.tffmt.outputs.formatted }}
+#   branch:
+#     description: Current branch 
+#     value: ${{ steps.getbranch.outputs.branch }}
 
 runs:
   using: composite 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -31,15 +31,12 @@ runs:
           sleep 1
         done;
 
-    - name: Sync repo
-      uses: actions/checkout@v3
-
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
-        recursive-path: .
-        recursive: true 
+        # recursive-path: .
+        # recursive: true 
         output-method: inject
         git-push: false
         fails-on-diff: true

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -60,10 +60,10 @@ runs:
         for rfile in ${before_list[@]}; do
           echo "File to check: $rfile"
           after=$(sha256sum $rfile| awk '{print $1}' )
-          rcheck=$(grep -e "$after" .readmechanges )
+          rcheck=$(grep -E "$after" .readmechanges )
           echo "after: $after, rcheck: $rcheck"
           # if [ -z "$rcheck" ]; then
-          #   echo "$file is new"
+          #   echo "$rfile is new"
           #   echo "isnewreadme $rfile" >> .readmechanges
           # fi
         done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -84,3 +84,4 @@ runs:
         #     --field sha="$SHA"
         #   sleep 1
         # done;
+        

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -46,11 +46,11 @@ runs:
     - name: Commit Readmes 
       shell: bash
       run: |
-        newdocs=$(git status|grep README|awk '{print $2}')
+        newdocs=$(git diff --name-only)
         for i in $newdocs; do echo "Changed: $newdoc"; done
         for push in $newdocs; do
           BRANCH="${{ github.ref_name }}"
-          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+          MESSAGE="chore: Terraform document updated $push from common workflows"
           SHA=$( git rev-parse $BRANCH:$push )
           CONTENT=$( base64 -i $push )
           gh api --method PUT /repos/${{ github.repository }}/contents/$push \

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -58,15 +58,15 @@ runs:
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for i in ${before_list[@]}; do echo "before_list item $i"
-        for rfile in ${before_list[@]}; do    
-          echo $rfile
-          # after=$(sha256sum $rfile|awk '{print $1}')    
-          # check=$(grep -e $after .readmechanges)    
-          # if [ -z "$check" ]; then                                                                                                                                          
-          #   echo "$rfile is new!"
-          #   echo "isnewreadme $rfile" >> .readmechanges    
-          # fi                                                                                                                                                                                              
-        done;
+        # for rfile in ${before_list[@]}; do    
+        #   echo $rfile
+        #   # after=$(sha256sum $rfile|awk '{print $1}')    
+        #   # check=$(grep -e $after .readmechanges)    
+        #   # if [ -z "$check" ]; then                                                                                                                                          
+        #   #   echo "$rfile is new!"
+        #   #   echo "isnewreadme $rfile" >> .readmechanges    
+        #   # fi                                                                                                                                                                                              
+        # done;
 
         # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -61,7 +61,7 @@ runs:
           echo "File to check: $rfile"
           after=$(sha256sum $rfile|awk '{print $1}')
           check=$(grep -e $after .readmechanges)
-          if [-z "check" ]; then
+          if [-z "$check" ]; then
             echo "$file is new"
             echo "isnewreadme $rfile" >> .readmechanges
           fi

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -54,27 +54,27 @@ runs:
     - name: Commit Readmes 
       shell: bash
       run: |
-        # Go through the list and compare, tag and append new stuff to list
-        before_list=$(cat .readmechanges|awk '{print $2}')    
-        for compare in $before_list; do    
-          after=$(sha256sum $compare|awk '{print $1}')    
-          check=$(grep -e $after .readmechanges)    
-          if [ -z "$check" ]; then                                                                                                                                          
-            echo "$compare is new!"
-            echo "isnewreadme $compare" >> .readmechanges    
-          fi                                                                                                                                                                                              
-        done;  
+        # # Go through the list and compare, tag and append new stuff to list
+        # before_list=$(cat .readmechanges|awk '{print $2}')    
+        # for compare in $before_list; do    
+        #   after=$(sha256sum $compare|awk '{print $1}')    
+        #   check=$(grep -e $after .readmechanges)    
+        #   if [ -z "$check" ]; then                                                                                                                                          
+        #     echo "$compare is new!"
+        #     echo "isnewreadme $compare" >> .readmechanges    
+        #   fi                                                                                                                                                                                              
+        # done;  
 
-        # Only changed documents here
+        # # Only changed documents here
         newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
 
-        for i in $newdocs; do echo "Changed: $newdoc"; done
-        for push in $newdocs; do
+        for i in $newdocs; do echo "Changed $newdoc"; done
+        for newdoc in $newdocs; do
           BRANCH="${{ github.ref_name }}"
-          MESSAGE="chore: Terraform document updated $push from common workflows"
-          SHA=$( git rev-parse $BRANCH:$push )
-          CONTENT=$( base64 -i $push )
-          gh api --method PUT /repos/${{ github.repository }}/contents/$push \
+          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+          SHA=$( git rev-parse $BRANCH:$newdoc )
+          CONTENT=$( base64 -i $newdoc )
+          gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
             --field message="$MESSAGE" \
             --field content="$CONTENT" \
             --field encoding="base64" \
@@ -82,4 +82,3 @@ runs:
             --field sha="$SHA"
           sleep 1
         done;
-          

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -24,7 +24,7 @@ runs:
     
     - name: Echo Values
       shell: bash
-      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }}""
+      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }}"
 
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -1,6 +1,11 @@
 name: Terraform Formatting
 Description: Apply Terraform formatting and commit changes to branch
 
+inputs:
+  github-token:
+    description: GitHub token to authenticate to the GitHub REST API from the host repo
+    required: true
+
 output:
   formatted-tf:
     description: Files Terraform fmt fixed
@@ -24,8 +29,9 @@ runs:
     
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
+      shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         for fixed in ${{ steps.tffmt.outputs.formatted }}; do
           export BRANCH="${{ steps.getbranch.outputs.branch }}"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -10,29 +10,29 @@ runs:
   using: composite 
   steps:
       # Use the REST API to commit changes, so we get automatic commit signing
-    - name: Commit signed changes
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        formatted=$(terraform fmt -recursive)
-        for i in $formatted; do echo $i; done;
-        for fixed in $formatted; do
-          BRANCH="${{ github.ref_name }}"
-          MESSAGE="chore: Terraform fmt of $fixed from common workflows"
-          SHA=$( git rev-parse $BRANCH:$fixed )
-          CONTENT=$( base64 -i $fixed )
-          gh api --method PUT /repos/${{ github.repository }}/contents/$fixed \
-            --field message="$MESSAGE" \
-            --field content="$CONTENT" \
-            --field encoding="base64" \
-            --field branch="$BRANCH" \
-            --field sha="$SHA"
-          sleep 1
-        done;
+    # - name: Commit signed changes
+    #   shell: bash
+    #   env:
+    #     GITHUB_TOKEN: ${{ github.token }}
+    #   run: |
+    #     formatted=$(terraform fmt -recursive)
+    #     for i in $formatted; do echo $i; done;
+    #     for fixed in $formatted; do
+    #       BRANCH="${{ github.ref_name }}"
+    #       MESSAGE="chore: Terraform fmt of $fixed from common workflows"
+    #       SHA=$( git rev-parse $BRANCH:$fixed )
+    #       CONTENT=$( base64 -i $fixed )
+    #       gh api --method PUT /repos/${{ github.repository }}/contents/$fixed \
+    #         --field message="$MESSAGE" \
+    #         --field content="$CONTENT" \
+    #         --field encoding="base64" \
+    #         --field branch="$BRANCH" \
+    #         --field sha="$SHA"
+    #       sleep 1
+    #     done;
 
-    - name: Sync repo
-      uses: actions/checkout@v3
+    # - name: Sync repo
+    #   uses: actions/checkout@v3
 
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,7 +57,7 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for compare in $before_list; do    
+        for compare in ${before_list[@]}; do    
           echo 'File compare: $compare'
           # after=$(sha256sum $compare|awk '{print $1}')    
           # check=$(grep -e $after .readmechanges)    
@@ -66,7 +66,6 @@ runs:
           #   echo "isnewreadme $compare" >> .readmechanges    
           # fi                                                                                                                                                                                              
         done
-        cat .readmechanges
 
         # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -1,5 +1,5 @@
 name: Terraform Formatting
-Description: Apply Terraform formatting and commit changes to branch
+Description: Fix formatting and document changes and commit back to the branch
 
 inputs:
   github-token:
@@ -10,7 +10,7 @@ runs:
   using: composite 
   steps:
       # Use the REST API to commit changes, so we get automatic commit signing
-    - name: Commit changes
+    - name: Commit signed changes
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
@@ -31,4 +31,10 @@ runs:
           sleep 1
         done;
 
-      
+    - name: Update Terraform Docs
+      uses: terraform-docs/gh-actions@v1.0.0
+      with:
+        recursive: true
+        git-commit-message: "chore: Auto updating Terraform Docs"
+        git-push: true
+        git-push-sign-off: true

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -30,7 +30,8 @@ runs:
     - name: Commit changes
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        # GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         formatted=$(terraform fmt -recursive)
         for fixed in $formatted; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -41,7 +41,8 @@ runs:
         recursive-path: .
         recursive: true 
         output-method: inject
-        git-push: false 
+        git-push: false
+        fails-on-diff: true
 
     - name: Commit Readmes 
       shell: bash

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -66,19 +66,21 @@ runs:
         # done;  
 
         # # Only changed documents here
-        newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
+        # newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
 
-        for i in $newdocs; do echo "Changed $newdoc"; done
-        for newdoc in $newdocs; do
-          BRANCH="${{ github.ref_name }}"
-          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
-          SHA=$( git rev-parse $BRANCH:$newdoc )
-          CONTENT=$( base64 -i $newdoc )
-          gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
-            --field message="$MESSAGE" \
-            --field content="$CONTENT" \
-            --field encoding="base64" \
-            --field branch="$BRANCH" \
-            --field sha="$SHA"
-          sleep 1
-        done;
+        # for i in $newdocs; do echo "Changed $newdoc"; done
+        # for newdoc in $newdocs; do
+        #   BRANCH="${{ github.ref_name }}"
+        #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+        #   SHA=$( git rev-parse $BRANCH:$newdoc )
+        #   CONTENT=$( base64 -i $newdoc )
+        #   gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
+        #     --field message="$MESSAGE" \
+        #     --field content="$CONTENT" \
+        #     --field encoding="base64" \
+        #     --field branch="$BRANCH" \
+        #     --field sha="$SHA"
+        #   sleep 1
+        # done;
+
+        echo "Testing indents"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -55,17 +55,16 @@ runs:
       shell: bash
       run: |
         # Go through the list and compare, tag and append new stuff to list
-        test -f .readmechanges && echo "File exists"
-        wc -l .readmechanges
-        before_list=$(cat .readmechanges|awk '{print $2}')    
-        for compare in $before_list; do    
-          after=$(sha256sum $compare|awk '{print $1}')    
-          check=$(grep -e $after .readmechanges)    
-          if [ -z "$check" ]; then                                                                                                                                          
-            echo "$compare is new!"
-            echo "isnewreadme $compare" >> .readmechanges    
-          fi                                                                                                                                                                                              
-        done;  
+        cat .readmechanges
+        # before_list=$(cat .readmechanges|awk '{print $2}')    
+        # for compare in $before_list; do    
+        #   after=$(sha256sum $compare|awk '{print $1}')    
+        #   check=$(grep -e $after .readmechanges)    
+        #   if [ -z "$check" ]; then                                                                                                                                          
+        #     echo "$compare is new!"
+        #     echo "isnewreadme $compare" >> .readmechanges    
+        #   fi                                                                                                                                                                                              
+        # done;  
         
         # Only changed documents here
         newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -56,19 +56,22 @@ runs:
       run: |
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
-        before_list=$(cat .readmechanges|awk '{print $2}')    
-        echo $(git diff --name-only)
-        # for rfile in ${before_list[@]}; do
-        #   echo "File to check: $rfile"
-        #   after=$(sha256sum $rfile| awk '{print $1}' )
-        #   grep -E $after 
-        #   # rcheck=$(cat .readmechanges| grep $after )
-        #   # echo "after: $after, rcheck: $rcheck"
-        #   # if [ -z "$rcheck" ]; then
-        #   #   echo "$rfile is new"
-        #   #   echo "isnewreadme $rfile" >> .readmechanges
-        #   # fi
-        # done;
+        before_hash=$(cat .readmechanges|awk '{print $1}')
+        before_list=$(cat .readmechanges|awk '{print $2}')                                                                                                                                      
+        for rfile in ${before_list[@]}; do                                                                                                                                                      
+          echo "File to check: $rfile"
+          after=$(sha256sum $rfile|awk '{print $1}')
+          match=0                                                                                                                                    
+          for oldhash in ${before_hash[@]}; do
+            if [ "$oldhash" = "$after" ]; then
+              match=1                                                                                                                                                    
+            fi                                                                                                                                     
+          done;
+          if [ 0 -eq $match ]; then                                                                                                                                 
+            echo "$rfile is new"
+            echo "isnewreadme $rfile" >> .readmechanges
+          fi
+        done;
 
         # # Only changed documents here
         # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -58,9 +58,9 @@ runs:
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for rfile in ${before_list[@]}; do
-          echo "File to rcheck: $rfile"
+          echo "File to check: $rfile"
           after=$(sha256sum $rfile| awk '{print $1}' )
-          rcheck=$(grep -e $after .readmechanges )
+          rcheck=$(grep -e "$after" .readmechanges )
           echo "after: $after, rcheck: $rcheck"
           # if [ -z "$rcheck" ]; then
           #   echo "$file is new"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -10,29 +10,29 @@ runs:
   using: composite 
   steps:
       # Use the REST API to commit changes, so we get automatic commit signing
-    # - name: Commit signed changes
-    #   shell: bash
-    #   env:
-    #     GITHUB_TOKEN: ${{ github.token }}
-    #   run: |
-    #     formatted=$(terraform fmt -recursive)
-    #     for i in $formatted; do echo $i; done;
-    #     for fixed in $formatted; do
-    #       BRANCH="${{ github.ref_name }}"
-    #       MESSAGE="chore: Terraform fmt of $fixed from common workflows"
-    #       SHA=$( git rev-parse $BRANCH:$fixed )
-    #       CONTENT=$( base64 -i $fixed )
-    #       gh api --method PUT /repos/${{ github.repository }}/contents/$fixed \
-    #         --field message="$MESSAGE" \
-    #         --field content="$CONTENT" \
-    #         --field encoding="base64" \
-    #         --field branch="$BRANCH" \
-    #         --field sha="$SHA"
-    #       sleep 1
-    #     done;
+    - name: Commit signed changes
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        formatted=$(terraform fmt -recursive)
+        for i in $formatted; do echo $i; done;
+        for fixed in $formatted; do
+          BRANCH="${{ github.ref_name }}"
+          MESSAGE="chore: Terraform fmt of $fixed from common workflows"
+          SHA=$( git rev-parse $BRANCH:$fixed )
+          CONTENT=$( base64 -i $fixed )
+          gh api --method PUT /repos/${{ github.repository }}/contents/$fixed \
+            --field message="$MESSAGE" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="$BRANCH" \
+            --field sha="$SHA"
+          sleep 1
+        done;
 
-    # - name: Sync repo
-    #   uses: actions/checkout@v3
+    - name: Sync repo
+      uses: actions/checkout@v3
 
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0
@@ -40,6 +40,4 @@ runs:
         working-dir: .
         recursive: true
         output-method: inject
-        git-commit-message: Updating docs from Terraform GitHub Actions common workflows
-        git-push: true
-        git-push-sign-off: true
+        git-push: false 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -1,13 +1,45 @@
 name: Terraform Formatting
 Description: Apply Terraform formatting and commit changes to branch
 
+output:
+  formatted-tf:
+    description: Files Terraform fmt fixed
+    value: ${{ steps.tffmt.outputs.formatted }}
+  branch:
+    description: Current branch 
+    value: ${{ steps.getbranch.outputs.branch }}
+
 runs:
   using: composite 
   steps:
     - name: Run Terraform formatting
       shell: bash
-      run: terraform fmt -recursive
+      id: tffmt
+      run: echo "formatted=$(terraform fmt -recursive)" >> $GITHUB_OUTPUT
     
+    - name: Get branch
+      shell: bash
+      id: getbranch 
+      run: echo "branch=$(git branch|grep \* |awk '{print $2}')" >> $GITHUB_OUTPUT
+    
+      # Use the REST API to commit changes, so we get automatic commit signing
+    - name: Commit changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        for fixed in ${{ steps.tffmt.outputs.formatted }}; do
+          export BRANCH="${{ steps.getbranch.outputs.branch }}"
+          export MESSAGE="chore: Terraform fmt of $fixed from common workflows"
+          export SHA=$( git rev-parse $BRANCH:$fixed )
+          export CONTENT=$( base64 -i $fixed )
+          gh api --method PUT /repos/defenseunicorns/${{ github.repository }}/contents/$fixed \
+            --field message="$MESSAGE" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="$BRANCH" \
+            --field sha="$SHA"
+        done;
+
     - name: Commit formatting changes 
       shell: bash
       run: |

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -8,8 +8,9 @@ runs:
       shell: bash
       run: terraform fmt -recursive
     
-    - uses: actions/checkout@v2
-    - run: |
+    - name: Commit formatting changes 
+      shell: bash
+      run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
         git commit -am "Fixed Terraform Formatting in GitHub action"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -56,19 +56,20 @@ runs:
       run: |
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
-        # before_list=$(cat .readmechanges|awk '{print $2}')    
-        # for compare in $before_list; do    
-        #   after=$(sha256sum $compare|awk '{print $1}')    
-        #   check=$(grep -e $after .readmechanges)    
-        #   if [ -z "$check" ]; then                                                                                                                                          
-        #     echo "$compare is new!"
-        #     echo "isnewreadme $compare" >> .readmechanges    
-        #   fi                                                                                                                                                                                              
-        # done;  
-        
+        before_list=$(cat .readmechanges|awk '{print $2}')    
+        for compare in $before_list; do    
+          after=$(sha256sum $compare|awk '{print $1}')    
+          check=$(grep -e $after .readmechanges)    
+          if [ -z "$check" ]; then                                                                                                                                          
+            echo "$compare is new!"
+            echo "isnewreadme $compare" >> .readmechanges    
+          fi                                                                                                                                                                                              
+        done
+        cat .readmechanges
+
         # Only changed documents here
-        newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
-        for i in $newdocs; do echo 'Changed $i'; done
+        # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
+        # for i in $newdocs; do echo 'Changed $i'; done
         # for newdoc in $newdocs; do
         #   BRANCH="${{ github.ref_name }}"
         #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -17,11 +17,6 @@ inputs:
 runs:
   using: composite 
   steps:
-    - name: Run Terraform formatting
-      shell: bash
-      id: tffmt
-      run: echo "formatted=$(terraform fmt -recursive)" >> $GITHUB_OUTPUT
-    
     - name: Get branch
       shell: bash
       id: getbranch 
@@ -29,31 +24,25 @@ runs:
     
     - name: Echo Values
       shell: bash
-      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }} with files ${{ steps.tffmt.outputs.formatted }}"
-    
+      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }}""
+
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        for fixed in ${{ steps.tffmt.outputs.formatted }}; do
-          export BRANCH="${{ steps.getbranch.outputs.branch }}"
-          export MESSAGE="chore: Terraform fmt of $fixed from common workflows"
-          export SHA=$( git rev-parse $BRANCH:$fixed )
-          export CONTENT=$( base64 -i $fixed )
+        formatted=$(terraform fmt -recursive)
+        for fixed in $formatted; do
+          local BRANCH="${{ steps.getbranch.outputs.branch }}"
+          local MESSAGE="chore: Terraform fmt of $fixed from common workflows"
+          local export SHA=$( git rev-parse $BRANCH:$fixed )
+          local export CONTENT=$( base64 -i $fixed )
           gh api --method PUT /repos/defenseunicorns/${{ github.repository }}/contents/$fixed \
             --field message="$MESSAGE" \
             --field content="$CONTENT" \
             --field encoding="base64" \
             --field branch="$BRANCH" \
             --field sha="$SHA"
+          sleep 1
         done;
-
-    - name: Commit formatting changes 
-      shell: bash
-      run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git commit -am "Fixed Terraform Formatting in GitHub action"
-        git push

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,14 +57,14 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for i in ${before_list}; do echo "before_list item $i"; done;
-        for compare in ${before_list[@]}; do    
-          echo 'File compare: $compare'
-          # after=$(sha256sum $compare|awk '{print $1}')    
+        for i in ${before_list}; do echo "before_list item $i"
+        for rfile in ${before_list}; do    
+          echo 'File rfile: $rfile'
+          # after=$(sha256sum $rfile|awk '{print $1}')    
           # check=$(grep -e $after .readmechanges)    
           # if [ -z "$check" ]; then                                                                                                                                          
-          #   echo "$compare is new!"
-          #   echo "isnewreadme $compare" >> .readmechanges    
+          #   echo "$rfile is new!"
+          #   echo "isnewreadme $rfile" >> .readmechanges    
           # fi                                                                                                                                                                                              
         done
 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -38,6 +38,11 @@ runs:
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
-        recursive: false 
+        recursive-path: .
+        recursive: true 
         output-method: inject
         git-push: false 
+
+    - name: Git diff
+      shell: bash
+      run: git diff

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -58,12 +58,13 @@ runs:
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for compare in $before_list; do    
-          after=$(sha256sum $compare|awk '{print $1}')    
-          check=$(grep -e $after .readmechanges)    
-          if [ -z "$check" ]; then                                                                                                                                          
-            echo "$compare is new!"
-            echo "isnewreadme $compare" >> .readmechanges    
-          fi                                                                                                                                                                                              
+          echo 'File compare: $compare'
+          # after=$(sha256sum $compare|awk '{print $1}')    
+          # check=$(grep -e $after .readmechanges)    
+          # if [ -z "$check" ]; then                                                                                                                                          
+          #   echo "$compare is new!"
+          #   echo "isnewreadme $compare" >> .readmechanges    
+          # fi                                                                                                                                                                                              
         done
         cat .readmechanges
 

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -62,30 +62,25 @@ runs:
           echo "File to check: $rfile"
           after=$(sha256sum $rfile|awk '{print $1}')
           match=0                                                                                                                                    
+          # git diff won't work and grep does not work, this is the alternative
           for oldhash in ${before_hash[@]}; do
             if [ "$oldhash" = "$after" ]; then
               match=1                                                                                                                                                    
             fi                                                                                                                                     
           done;
+
           if [ 0 -eq $match ]; then                                                                                                                                 
+            # Say which file is being committed and commit it. 
             echo "$rfile is new"
-            echo "isnewreadme $rfile" >> .readmechanges
+            BRANCH="${{ github.ref_name }}"
+            MESSAGE="chore: Terraform document updated $rfile from common workflows"
+            SHA=$( git rev-parse $BRANCH:$rfile )
+            CONTENT=$( base64 -i $rfile )
+            gh api --method PUT /repos/${{ github.repository }}/contents/$rfile \
+              --field message="$MESSAGE" \
+              --field content="$CONTENT" \
+              --field encoding="base64" \
+              --field branch="$BRANCH" \
+              --field sha="$SHA"
           fi
         done;
-
-        # # Only changed documents here
-        # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
-        # for i in $newdocs; do echo 'Changed $i'; done
-        # for newdoc in ${newdocs[@]}; do
-        #   BRANCH="${{ github.ref_name }}"
-        #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"
-        #   SHA=$( git rev-parse $BRANCH:$newdoc )
-        #   CONTENT=$( base64 -i $newdoc )
-        #   gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
-        #     --field message="$MESSAGE" \
-        #     --field content="$CONTENT" \
-        #     --field encoding="base64" \
-        #     --field branch="$BRANCH" \
-        #     --field sha="$SHA"
-        #   sleep 1
-        # done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -18,7 +18,7 @@ runs:
         formatted=$(terraform fmt -recursive)
         for i in $formatted; do echo $i; done;
         for fixed in $formatted; do
-          BRANCH="${{ branch.ref_name }}"
+          BRANCH="${{ github.ref_name }}"
           MESSAGE="chore: Terraform fmt of $fixed from common workflows"
           SHA=$( git rev-parse $BRANCH:$fixed )
           CONTENT=$( base64 -i $fixed )

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,7 +57,7 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for i in ${before_list[@]}; do echo "before_list item $i"
+        for i in ${before_list[@]}; do echo "before_list item $i"; done;
         # for rfile in ${before_list[@]}; do    
         #   echo $rfile
         #   # after=$(sha256sum $rfile|awk '{print $1}')    

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -31,12 +31,22 @@ runs:
           sleep 1
         done;
 
+    - name: Set Diff Readme recursive
+      shell: bash
+      run: |
+      # Stash a list of all readme's found and their sha
+      readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
+      for readme in $readme_list; do
+        echo "Readme found: $readme"
+        sha256sum $readme >> .readmechanges
+      done;
+
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .
-        # recursive-path: .
-        # recursive: true 
+        recursive-path: .
+        recursive: true 
         output-method: inject
         git-push: false
         fails-on-diff: true
@@ -44,7 +54,20 @@ runs:
     - name: Commit Readmes 
       shell: bash
       run: |
-        newdocs=$(git diff --name-only)
+        # Go through the list and compare, tag and append new stuff to list
+        before_list=$(cat .readmechanges|awk '{print $2}')    
+        for compare in $before_list; do    
+          after=$(sha256sum $compare|awk '{print $1}')    
+          check=$(grep -e $after .readmechanges)    
+          if [ -z "$check" ]; then                                                                                                                                          
+            echo "$compare is new!"
+            echo "isnewreadme $compare" >> .readmechanges    
+          fi                                                                                                                                                                                              
+        done;  
+
+        # Only changed documents here
+        newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
+
         for i in $newdocs; do echo "Changed: $newdoc"; done
         for push in $newdocs; do
           BRANCH="${{ github.ref_name }}"
@@ -59,5 +82,4 @@ runs:
             --field sha="$SHA"
           sleep 1
         done;
-        cat README.md
           

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,8 +57,8 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        for i in ${before_list}; do echo "before_list item $i"
-        for rfile in ${before_list}; do    
+        for i in ${before_list[@]}; do echo "before_list item $i"
+        for rfile in ${before_list[@]}; do    
           echo $rfile
           # after=$(sha256sum $rfile|awk '{print $1}')    
           # check=$(grep -e $after .readmechanges)    

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -59,28 +59,28 @@ runs:
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for rfile in ${before_list[@]}; do
           echo "File to check: $rfile"
-          after=$(sha256sum $rfile|awk '{print $1}')
-          check=$(grep -e $after .readmechanges)
-          echo "check: $check, after: $after"
+          after=$(sha256sum $rfile| awk '{print $1}' )
+          # check=$(grep -e $after .readmechanges )
+          echo "after: $after"
           # if [ -z "$check" ]; then
           #   echo "$file is new"
           #   echo "isnewreadme $rfile" >> .readmechanges
           # fi
         done;
 
-        Only changed documents here
-        newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
-        for i in $newdocs; do echo 'Changed $i'; done
-        for newdoc in $newdocs; do
-          BRANCH="${{ github.ref_name }}"
-          MESSAGE="chore: Terraform document updated $newdoc from common workflows"
-          SHA=$( git rev-parse $BRANCH:$newdoc )
-          CONTENT=$( base64 -i $newdoc )
-          gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
-            --field message="$MESSAGE" \
-            --field content="$CONTENT" \
-            --field encoding="base64" \
-            --field branch="$BRANCH" \
-            --field sha="$SHA"
-          sleep 1
-        done;
+        # # Only changed documents here
+        # newdocs=$(grep -e isnewreadme .readmechanges|awk '{print $2}')
+        # for i in $newdocs; do echo 'Changed $i'; done
+        # for newdoc in ${newdocs[@]}; do
+        #   BRANCH="${{ github.ref_name }}"
+        #   MESSAGE="chore: Terraform document updated $newdoc from common workflows"
+        #   SHA=$( git rev-parse $BRANCH:$newdoc )
+        #   CONTENT=$( base64 -i $newdoc )
+        #   gh api --method PUT /repos/${{ github.repository }}/contents/$newdoc \
+        #     --field message="$MESSAGE" \
+        #     --field content="$CONTENT" \
+        #     --field encoding="base64" \
+        #     --field branch="$BRANCH" \
+        #     --field sha="$SHA"
+        #   sleep 1
+        # done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -57,7 +57,7 @@ runs:
         # Go through the list and compare, tag and append new stuff to list
         cat .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
-        git diff --name-only
+        echo $(git diff --name-only)
         # for rfile in ${before_list[@]}; do
         #   echo "File to check: $rfile"
         #   after=$(sha256sum $rfile| awk '{print $1}' )

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -24,7 +24,8 @@ runs:
     
     - name: Echo Values
       shell: bash
-      run: echo "Branch; ${{ steps.getbranch.outputs.branch }}"
+      run: echo "Branch; ${{ github.ref_name }}"
+      # run: echo "Branch; ${{ steps.getbranch.outputs.branch }}"
 
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
@@ -38,9 +39,9 @@ runs:
         for fixed in $formatted; do
           BRANCH="${{ steps.getbranch.outputs.branch }}"
           MESSAGE="chore: Terraform fmt of $fixed from common workflows"
-          export SHA=$( git rev-parse $BRANCH:$fixed )
-          export CONTENT=$( base64 -i $fixed )
-          gh api --method PUT /repos/defenseunicorns/${{ github.repository }}/contents/$fixed \
+          SHA=$( git rev-parse $BRANCH:$fixed )
+          CONTENT=$( base64 -i $fixed )
+          gh api --method PUT /repos/${{ github.repository }}/contents/$fixed \
             --field message="$MESSAGE" \
             --field content="$CONTENT" \
             --field encoding="base64" \

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -27,6 +27,10 @@ runs:
       id: getbranch 
       run: echo "branch=$(git branch|grep \* |awk '{print $2}')" >> $GITHUB_OUTPUT
     
+    - name: Echo Values
+      shell: bash
+      run: echo "Branch;  ${{ steps.getbranch.outputs.branch }} with files ${{ steps.tffmt.outputs.formatted }}"
+    
       # Use the REST API to commit changes, so we get automatic commit signing
     - name: Commit changes
       shell: bash

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -60,7 +60,7 @@ runs:
         for rfile in ${before_list[@]}; do
           echo "File to check: $rfile"
           after=$(sha256sum $rfile| awk '{print $1}' )
-          rcheck=$(grep -E "$after" .readmechanges )
+          rcheck=$(grep -E $after .readmechanges )
           echo "after: $after, rcheck: $rcheck"
           # if [ -z "$rcheck" ]; then
           #   echo "$rfile is new"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -62,4 +62,5 @@ runs:
             --field sha="$SHA"
           sleep 1
         done;
+        cat README.md
           

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -56,6 +56,7 @@ runs:
       run: |
         # Go through the list and compare, tag and append new stuff to list
         test -f .readmechanges && echo "File exists"
+        wc -l .readmechanges
         before_list=$(cat .readmechanges|awk '{print $2}')    
         for compare in $before_list; do    
           after=$(sha256sum $compare|awk '{print $1}')    
@@ -65,10 +66,9 @@ runs:
             echo "isnewreadme $compare" >> .readmechanges    
           fi                                                                                                                                                                                              
         done;  
-
+        
         # Only changed documents here
         newdocs=$(grep -e "isnewreadme" .readmechanges|awk '{print $2}')
-
         for i in $newdocs; do echo "Changed $newdoc"; done
         # for newdoc in $newdocs; do
         #   BRANCH="${{ github.ref_name }}"

--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -13,6 +13,10 @@ on:
         description: 'Regula variable for terraform directories, either space or new line seperated'
         default: '.'
         type: string
+      github-token:
+        required: true
+        description: GitHub token
+        type: string
 
 run-name: ${{ github.actor }} is scanning Terraform in ${{ github.repository }}
 jobs:
@@ -24,6 +28,8 @@ jobs:
 
       - name: Terraform format
         uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@inline-fmt
+        with:
+          github-token: ${{ inputs.github-token }}
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v3

--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Terraform format
-        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@inline-fmt
+        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@main
         with:
           github-token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
**Additions:**
* Add a GitHub action to perform `terraform fmt -recursive`
* Run Terraform documents recursively.
* Sign commits and push to the same branch from the GitHub action.
* Work around for finding and committing files since GitHub actions does not have `grep -e` or `git diff --name-only` functionality available. 