### PR TITLE
fix: sleep to ensure rate limit does not stop commits

### DIFF
--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -37,7 +37,7 @@ runs:
       run: |
         # Stash a list of all readmes found and their sha
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
-        csv_found = ''
+        csv_found=''
         for readme in $readme_list; do
           # Finds only the Readme with .tf in the dir.
           directory_check=${$readme:0:-9}

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -85,5 +85,6 @@ runs:
               --field encoding="base64" \
               --field branch="$BRANCH" \
               --field sha="$SHA"
+            sleep 1
           fi
         done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -40,7 +40,7 @@ runs:
         csv_found=''
         for readme in $readme_list; do
           # Finds only the Readme with .tf in the dir.
-          directory_check=${$readme:0:-9}
+          directory_check=${readme:0:-9}
           has_tf=$(ls $directory_check| grep .tf| wc -l)
           if [ has_tf -ge 0 ]; then 
             echo "Readme found: $readme"

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -45,7 +45,7 @@ runs:
           has_tf=$(ls $directory_check| grep .tf| wc -l)
           if [ $has_tf -ge 0 ]; then 
             echo "Readme found: $readme"
-            csv_found+="$readme,"
+            csv_found+="$directory_check,"
             sha256sum $readme >> .readmechanges
           fi
         done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -15,6 +15,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
+        touch foo.blake
         git status --porcelain=v1 
         formatted=$(terraform fmt -recursive)
         for i in $formatted; do echo $i; done;

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -39,8 +39,6 @@ runs:
       run: |
         # Stash a list of all readmes found and their sha
         touch .readmechanges
-        # tfdirs=$(find . -type f -name "*.tf" | grep -v .cache | grep -v ".terraform" | rev | cut -d '/' -f 2- | rev | sort -u) 
-        # for i in ${tfdirs[@]}; do touch $i/README.md; done
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep -v .config|grep README.md)
         csv_found=''
         for readme in $readme_list; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -15,6 +15,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
+        git status --porcelain=v1 
         formatted=$(terraform fmt -recursive)
         for i in $formatted; do echo $i; done;
         for fixed in $formatted; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -36,6 +36,7 @@ runs:
       shell: bash
       run: |
         # Stash a list of all readmes found and their sha
+        touch .readmechanges
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
         csv_found=''
         for readme in $readme_list; do
@@ -44,11 +45,12 @@ runs:
           has_tf=$(ls $directory_check| grep .tf| wc -l)
           if [ has_tf -ge 0 ]; then 
             echo "Readme found: $readme"
-            csv_found="$csv_found,$readme"
+            csv_found+="$readme,"
             sha256sum $readme >> .readmechanges
           fi
         done;
-        echo "csv_readme=$csv_found" >> $GITHUB_OUTPUT
+        # removes final comma
+        echo "csv_readme=${csv_found%,}" >> $GITHUB_OUTPUT
 
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -37,13 +37,13 @@ runs:
       run: |
         # Stash a list of all readmes found and their sha
         touch .readmechanges
-        readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
+        readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep -v .config|grep README.md)
         csv_found=''
         for readme in $readme_list; do
           # Finds only the Readme with .tf in the dir.
           directory_check=${readme:0:-9}
           has_tf=$(ls $directory_check| grep .tf| wc -l)
-          if [ has_tf -ge 0 ]; then 
+          if [ $has_tf -ge 0 ]; then 
             echo "Readme found: $readme"
             csv_found+="$readme,"
             sha256sum $readme >> .readmechanges

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -37,6 +37,8 @@ runs:
       run: |
         # Stash a list of all readmes found and their sha
         touch .readmechanges
+        tfdirs=$(find . -type f -name "*.tf" | grep -v .cache | grep -v ".terraform" | rev | cut -d '/' -f 2- | rev | sort -u) 
+        for i in ${tfdirs[@]}; do touch $i/README.md; done
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep -v .config|grep README.md)
         csv_found=''
         for readme in $readme_list; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -39,8 +39,8 @@ runs:
       run: |
         # Stash a list of all readmes found and their sha
         touch .readmechanges
-        tfdirs=$(find . -type f -name "*.tf" | grep -v .cache | grep -v ".terraform" | rev | cut -d '/' -f 2- | rev | sort -u) 
-        for i in ${tfdirs[@]}; do touch $i/README.md; done
+        # tfdirs=$(find . -type f -name "*.tf" | grep -v .cache | grep -v ".terraform" | rev | cut -d '/' -f 2- | rev | sort -u) 
+        # for i in ${tfdirs[@]}; do touch $i/README.md; done
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep -v .config|grep README.md)
         csv_found=''
         for readme in $readme_list; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -15,8 +15,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        touch foo.blake
-        git status --porcelain=v1 
         formatted=$(terraform fmt -recursive)
         for i in $formatted; do echo $i; done;
         for fixed in $formatted; do

--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -32,21 +32,28 @@ runs:
         done;
 
     - name: Set Diff Readme recursive
+      id: find_readme
       shell: bash
       run: |
         # Stash a list of all readmes found and their sha
         readme_list=$(find . -print|grep -v '.git'|grep -v .terraform|grep README.md)
+        csv_found = ''
         for readme in $readme_list; do
-          echo "Readme found: $readme"
-          sha256sum $readme >> .readmechanges
+          # Finds only the Readme with .tf in the dir.
+          directory_check=${$readme:0:-9}
+          has_tf=$(ls $directory_check| grep .tf| wc -l)
+          if [ has_tf -ge 0 ]; then 
+            echo "Readme found: $readme"
+            csv_found="$csv_found,$readme"
+            sha256sum $readme >> .readmechanges
+          fi
         done;
+        echo "csv_readme=$csv_found" >> $GITHUB_OUTPUT
 
     - name: Update Terraform Docs
       uses: terraform-docs/gh-actions@v1.0.0
       with:
-        working-dir: .
-        recursive-path: .
-        recursive: true 
+        working-dir: ${{ steps.find_readme.outputs.csv_readme }}
         output-method: inject
         git-push: false
         fails-on-diff: true

--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Terraform format
-        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@gh-sleep-commits
+        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@fix/gh-sleep-commits
         with:
           github-token: ${{ inputs.github-token }}
 

--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
       tf-dirs:
         required: false
-        description: 'Regula variable for terraform directories, either space or new line seperated'
+        description: 'Regula variable for terraform directories, either space or new line separated'
         default: '.'
         type: string
       github-token:
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Terraform format
-        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@main
+        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@gh-sleep-commits
         with:
           github-token: ${{ inputs.github-token }}
 

--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Terraform format
-        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@fix/gh-sleep-commits
+        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@main
         with:
           github-token: ${{ inputs.github-token }}
 


### PR DESCRIPTION
**Fixes:**
* Without a sleep on the `gh api` command, the rate limit gets in the way from multiple files being pushed. 
* Better handling of scanning directories with Terraform and updating the Readme.