### PR TITLE
commenting out terraform docs

### DIFF
--- a/.github/actions/terraform-fmt/action.yaml
+++ b/.github/actions/terraform-fmt/action.yaml
@@ -28,13 +28,13 @@ runs:
         # removes final comma
         echo "csv_readme=${csv_found%,}" >> $GITHUB_OUTPUT
 
-    - name: Update Terraform Docs
-      uses: terraform-docs/gh-actions@v1.0.0
-      with:
-        working-dir: ${{ steps.find_readme.outputs.csv_readme }}
-        output-method: inject
-        git-push: false
-        fails-on-diff: true
+    # - name: Update Terraform Docs
+    #   uses: terraform-docs/gh-actions@v1.0.0
+    #   with:
+    #     working-dir: ${{ steps.find_readme.outputs.csv_readme }}
+    #     output-method: inject
+    #     git-push: false
+    #     fails-on-diff: true
 
     - name: terraform fmt
       shell: bash


### PR DESCRIPTION
Commenting out the Terraform Docs functionality out of a security concern discussed [here](https://github.com/defenseunicorns/uds-aws-ci-k3d/pull/8#issuecomment-1595611171).
