### PR TITLE
move terraform fmt action into workflow

### DIFF
--- a/.github/workflows/terraform-scan.yaml
+++ b/.github/workflows/terraform-scan.yaml
@@ -29,11 +29,80 @@ jobs:
       - name: Terraform init
         run: terraform init
 
-      - name: Terraform format
-        # uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@main
-        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@25-common-iac-test
-        with:
-          github-token: ${{ inputs.github-token }}
+#      - name: Terraform format
+#        # uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@main
+#        uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-fmt@25-common-iac-test
+#        with:
+#          github-token: ${{ inputs.github-token }}
+
+      - name: terraform fmt
+        run: terraform fmt -recursive
+
+      - name: terraform validate
+        run: terraform validate
+
+        # Use the GraphQL API to commit changes, so we get automatic commit signing
+        # The REST contents API can't be used as easily because it only supports making single file commits
+      - name: Commit updated files
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          additions=()
+          removed=()
+          while IFS= read -r -d $'\0' status_line; do
+              filename="${status_line:3}"
+              git_status="${status_line:0:2}"
+
+              if [ "$git_status" = "D " ]; then
+                  removed+=("$filename")
+              else
+                  additions+=("$filename")
+              fi
+          done < <(git status --porcelain=v1 -z)
+
+          if [ "${#additions[@]}" -eq 0 ] ; then
+            echo "No files updated, skipping commit"
+            exit 0
+          fi
+
+          commitMessage="chore: terraform README update and fmt"
+
+          # for now, we ignore $removed files, but they could be handled similarly (it's just harder to send two lists of positional input files into jq)
+          # jq's iteration over inputs will skip over files with 0 lines (empty files)
+
+          jq \
+            --null-input \
+            --raw-input \
+            --arg repositoryNameWithOwner "$GITHUB_REPOSITORY" \
+            --arg branchName "$GITHUB_REF_NAME" \
+            --arg expectedHeadOid "$GITHUB_SHA" \
+            --arg commitMessage "$commitMessage" \
+            '
+          {
+            "query": "mutation ($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }",
+            "variables": {
+              "input": {
+                "branch": {
+                  "repositoryNameWithOwner": $repositoryNameWithOwner,
+                  "branchName": $branchName
+                },
+                "message": {
+                  "headline": $commitMessage
+                },
+                "fileChanges": {
+                  "additions": [reduce inputs as $line ({}; .[input_filename] += [$line]) | map_values(join("\n")) | to_entries[] | {path: .key, contents: .value | @base64}]
+                },
+                "expectedHeadOid": $expectedHeadOid
+              }
+            }
+          }' "${additions[@]}" | curl https://api.github.com/graphql \
+            --silent \
+            --fail-with-body \
+            --oauth2-bearer "$(gh auth token)" \
+            --data @-
 
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v3


### PR DESCRIPTION
Created due a discussion started in https://github.com/defenseunicorns/uds-common-workflows/pull/46. 

**Changes:** Using a single shared workflow versus a single shared workflow that calls a shared action within the same repository. 