### PR TITLE
change go test fix parallel testing with logging

### DIFF
--- a/.github/actions/terraform-test/action.yaml
+++ b/.github/actions/terraform-test/action.yaml
@@ -29,5 +29,5 @@ runs:
 
     - name: Test with terratest
       shell: bash
-      run: go test -count ${{ inputs.test_retry }} -v ./...
+      run: go test ./... -count ${{ inputs.test_retry }} -p 1 -v
 

--- a/.github/actions/terraform-test/action.yaml
+++ b/.github/actions/terraform-test/action.yaml
@@ -29,5 +29,6 @@ runs:
 
     - name: Test with terratest
       shell: bash
-      run: go test ./... -count ${{ inputs.test_retry }} -p 1 -v
+      working-directory: ./test
+      run: go test -count ${{ inputs.test_retry }} -v .
 


### PR DESCRIPTION
**Changes:**
* Change parallel testing for synchronous testing feedback in pipelines (and prevent termination from false idling on longer tests).

Closes #48. 

