### PR TITLE
fix: Add timeout to Terratest shared action

### DIFF
--- a/.github/actions/terraform-test/action.yaml
+++ b/.github/actions/terraform-test/action.yaml
@@ -7,6 +7,11 @@ inputs:
     description: 'Retry count'
     default: 1
     type: number
+  test_timeout:
+    required: false
+    description: Go test timeout as a string
+    default: 30m
+    type: string
 
 defaults:
   run:

--- a/.github/actions/terraform-test/action.yaml
+++ b/.github/actions/terraform-test/action.yaml
@@ -3,12 +3,10 @@ description: Testing Terraform with Terratest
 
 inputs:
   test_retry:
-    required: false
     description: 'Retry count'
     default: 1
     type: number
   test_timeout:
-    required: false
     description: Go test timeout as a string
     default: 30m
     type: string

--- a/.github/actions/terraform-test/action.yaml
+++ b/.github/actions/terraform-test/action.yaml
@@ -35,5 +35,5 @@ runs:
     - name: Test with terratest
       shell: bash
       working-directory: ./test
-      run: go test -count ${{ inputs.test_retry }} -v .
+      run: go test -count ${{ inputs.test_retry }} -timeout ${{ inputs.test_timeout }} -v .
 

--- a/documents/terraform/terraform-test.md
+++ b/documents/terraform/terraform-test.md
@@ -13,6 +13,11 @@ For this GitHub Workflow to be utilized properly, a common structure and pattern
   * description: 'Retry count'
   * default: 1
   * type: number
+* test_timeout:
+  * required: false
+  * description: Go test timeout as a string
+  * default: 30m
+  * type: string
 
 *Example found in this [section](#example-test).*
 
@@ -111,6 +116,7 @@ jobs:
         uses: defenseunicorns/uds-common-workflows/.github/actions/terraform-test@main
         with:
           test_retry: 1
+          test_timeout: 2h
 ```
 
 ## Workflow Diagram


### PR DESCRIPTION
Adds a configuration option for setting a timeout for Terratest. 

Closes #52.